### PR TITLE
Wire frasermolyneux-copilot MCP server (pinned to v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,3 +10,9 @@
 - **Response handling internals**: Consumers typically call `ExecuteAsync` then map with extension helpers in `Extensions/RestResponseExtensions.cs` and `Extensions/RequestExtensions.cs` to `ApiResponse<T>` / `ApiResult<T>`. Keep error handling consistent with these wrappers.
 - **Web helpers**: `MX.Api.Web.Extensions` contains ASP.NET Core extensions to translate API results into `IActionResult` responses; use when building providers to match the shared envelope conventions.
 - **Docs**: High-level patterns are documented in `docs/` (API design, provider/consumer guidance, versioned clients, package maintenance, dotnet support, workflows). Align code changes with these references and update docs if behaviors diverge.
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
 
       - name: Setup .NET
@@ -42,3 +43,14 @@ jobs:
             dotnet-version: |
               9.0.x
               10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: |
+          npm ci
+          npm run build

--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 
 ## Security
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+This repo wires the shared `frasermolyneux-copilot` MCP server (catalog server for org standards, instructions, prompts, agents). See `.github-copilot/mcp-server/README.md` (checked out by `.github/workflows/copilot-setup-steps.yml`) for the tool surface, content-root resolution, and per-client wire-up snippets.


### PR DESCRIPTION
Adds the shared `frasermolyneux-copilot` MCP catalog server to this repo's Copilot agent runtime so agents prefer the catalog's `list_*` / `get_*` / `search_*` tools over local heuristics when answering org-convention questions. Mirrors the pattern already shipped to `portal-core`, pinned to `frasermolyneux/.github-copilot` tag `v0.1.0`.

## Changes

- **`.github/workflows/copilot-setup-steps.yml`** — pinned the existing shared-copilot checkout to `ref: refs/tags/v0.1.0` (rather than appending a duplicate checkout step, since the existing one already targets `path: .github-copilot`), and appended `actions/setup-node@v6` (Node 20.x) plus a `Build MCP server` step that runs `npm ci && npm run build` in `.github-copilot/mcp-server`.
- **`.github/copilot/mcp_config.json`** — new file; registers the local stdio MCP server pointing at the built `dist/index.js` with `GH_COPILOT_CONTENT_ROOT=.github-copilot`.
- **`.github/copilot-instructions.md`** — appended the canonical `## Org conventions via MCP (when available)` section sourced from the catalog (SHA256 prefix `DDAC8AA449794730` verified against the catalog source-of-truth).
- **`README.md`** — short `## Local dev: MCP wire-up` pointer to the shared `mcp-server/README.md` for full docs.

## Notes for reviewers

- The setup-steps file already had a `.github-copilot` checkout, so the change there is a minimal in-place edit (add `ref:`) plus the appended Node/MCP steps. A second checkout at the same path would clash.
- `AGENTS.md` is intentionally **not** added in this PR. It does not exist in this repo and is owned by a separate metadata-bootstrap flow; once it lands, the same canonical snippet should be mirrored there byte-identically.
- `v0.1.0` is a tag (mutable) rather than a SHA pin. This is the deliberate org-wide convention for this rollout; the source repo is org-owned.
- The Node build runs with `contents: read` only and before the agent starts, so blast radius matches the existing setup-steps trust boundary.