### PR TITLE
Add SharedCacheConfiguration for unified API client registrations

### DIFF
--- a/src/MX.Api.Client.Tests/Extensions/UnifiedApiClientRegistrationTests.cs
+++ b/src/MX.Api.Client.Tests/Extensions/UnifiedApiClientRegistrationTests.cs
@@ -1,0 +1,230 @@
+using Microsoft.Extensions.DependencyInjection;
+using MX.Api.Client.Configuration;
+using MX.Api.Client.Extensions;
+using MX.Api.Client.Tests.TestClients;
+using MX.Caching.Abstractions;
+using Xunit;
+
+namespace MX.Api.Client.Tests.Extensions;
+
+/// <summary>
+/// DI-composition regression tests for the "unified API client" registration scenario.
+/// A downstream unified client registers many typed sub-API clients by passing the SAME
+/// configureOptions delegate to <c>AddTypedApiClient</c> for each sub-API. When that delegate
+/// contains cache expressions against multiple sub-APIs, the classic per-client scope check
+/// throws when the delegate is executed for a sibling sub-API — aborting host startup.
+///
+/// These tests lock in the new <see cref="SharedCacheConfiguration"/> capability that captures
+/// the delegate once and applies only the matching operations per registered sub-API, and
+/// prove the old <see cref="ApiClientOptionsBuilder{TOptions, TBuilder}.WithCaching(Action{CacheBuilder})"/>
+/// path continues to throw so single-client typo safety is preserved.
+/// </summary>
+public class UnifiedApiClientRegistrationTests
+{
+    /// <summary>
+    /// Reproduces the production incident: sharing one <c>WithCaching(...)</c> delegate that mixes
+    /// cache expressions from multiple sub-APIs across per-client registrations must still throw.
+    /// This is intentional — proves the safety net for genuine single-client typos is intact.
+    /// </summary>
+    [Fact]
+    public void SharedWithCachingDelegate_AcrossMultipleTypedClients_StillThrows_ProvingRepro()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddSingleton<IMxCache>(new FakeMxCache());
+
+        Action<TestApiOptionsBuilder> shared = SharedConfigureThatThrows;
+
+        // First typed client registration executes the delegate scoped to ISubApiA. The ISubApiB
+        // expression inside the delegate hits the classic scope check and throws immediately.
+        _ = Assert.Throws<ArgumentException>(() =>
+            services.AddTypedApiClient<ISubApiA, SubApiA, TestApiOptions, TestApiOptionsBuilder>(shared));
+
+        static void SharedConfigureThatThrows(TestApiOptionsBuilder builder)
+        {
+            _ = builder
+                .WithBaseUrl("https://api.example.com")
+                .WithCachePartition("tenant:1")
+                .WithCaching(cache => cache
+                    .UseLibraryDefaults()
+                    .InMemory<ISubApiA, Task<string>>(api => api.GetA(1, default), TimeSpan.FromSeconds(60))
+                    .NotCached<ISubApiB, Task<string>>(api => api.GetB(2, default)));
+        }
+    }
+
+    /// <summary>
+    /// The fix: swap <c>WithCaching(...)</c> for <c>WithSharedCaching(sharedCacheConfiguration)</c>.
+    /// The unified client keeps its one-delegate-for-all pattern; each per-client registration only
+    /// applies the operations whose declaring interface is assignable from the current typed client.
+    /// </summary>
+    [Fact]
+    public void SharedWithCachingDelegate_ViaSharedCacheConfiguration_ComposesAllTypedClientsCleanly()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddSingleton<IMxCache>(new FakeMxCache());
+
+        var sharedCache = new SharedCacheConfiguration(cache => cache
+            .UseLibraryDefaults()
+            .InMemory<ISubApiA, Task<string>>(api => api.GetA(1, default), TimeSpan.FromSeconds(60))
+            .NotCached<ISubApiB, Task<string>>(api => api.GetB(2, default)));
+
+        // Register three sub-APIs against the same shared delegate.
+        _ = services.AddTypedApiClient<ISubApiA, SubApiA, TestApiOptions, TestApiOptionsBuilder>(Shared);
+        _ = services.AddTypedApiClient<ISubApiB, SubApiB, TestApiOptions, TestApiOptionsBuilder>(Shared);
+        _ = services.AddTypedApiClient<ISubApiC, SubApiC, TestApiOptions, TestApiOptionsBuilder>(Shared);
+
+        // Finalize: assert every captured operation matched at least one registered client.
+        sharedCache.ValidateAllOperationsMatched();
+
+        // BuildServiceProvider must succeed — this is the exact assertion that would have caught the incident.
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<ISubApiA>());
+        Assert.NotNull(provider.GetService<ISubApiB>());
+        Assert.NotNull(provider.GetService<ISubApiC>());
+
+        void Shared(TestApiOptionsBuilder builder)
+        {
+            _ = builder
+                .WithBaseUrl("https://api.example.com")
+                .WithCachePartition("tenant:1")
+                .WithSharedCaching(sharedCache);
+        }
+    }
+
+    /// <summary>
+    /// Each cache operation must land ONLY on the typed client whose interface declares it — no cross-client bleed.
+    /// </summary>
+    [Fact]
+    public void SharedCacheConfiguration_OperationsLandOnMatchingClientOnly_NoCrossClientBleed()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddSingleton<IMxCache>(new FakeMxCache());
+
+        var sharedCache = new SharedCacheConfiguration(cache => cache
+            .UseLibraryDefaults()
+            .InMemory<ISubApiA, Task<string>>(api => api.GetA(1, default), TimeSpan.FromSeconds(60))
+            .NotCached<ISubApiB, Task<string>>(api => api.GetB(2, default)));
+
+        Action<TestApiOptionsBuilder> shared = Shared;
+
+        _ = services.AddTypedApiClient<ISubApiA, SubApiA, TestApiOptions, TestApiOptionsBuilder>(shared);
+        _ = services.AddTypedApiClient<ISubApiB, SubApiB, TestApiOptions, TestApiOptionsBuilder>(shared);
+        _ = services.AddTypedApiClient<ISubApiC, SubApiC, TestApiOptions, TestApiOptionsBuilder>(shared);
+
+        using var provider = services.BuildServiceProvider();
+        var allOptions = provider.GetServices<TestApiOptions>().ToList();
+
+        // Three registrations, three distinct options singletons.
+        Assert.Equal(3, allOptions.Count);
+
+        // Every options instance has UseLibraryCacheDefaults because the shared configuration opted in.
+        Assert.All(allOptions, o => Assert.True(o.UseLibraryCacheDefaults));
+
+        // Two ops total across the three registrations; the third client (ISubApiC) is unaffected by consumer ops.
+        var totalOperations = allOptions.Sum(o => o.CachePolicyOperations.Count);
+        Assert.Equal(2, totalOperations);
+
+        foreach (var options in allOptions)
+        {
+            Assert.All(options.CachePolicyOperations, kvp => Assert.NotNull(kvp.Key.DeclaringType));
+        }
+
+        // Verify per-interface landing precisely.
+        var byDeclaringType = allOptions
+            .SelectMany(o => o.CachePolicyOperations.Select(kvp => (Options: o, kvp.Key, kvp.Value)))
+            .GroupBy(x => x.Key.DeclaringType!)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        Assert.True(byDeclaringType.ContainsKey(typeof(ISubApiA)));
+        Assert.True(byDeclaringType.ContainsKey(typeof(ISubApiB)));
+        Assert.False(byDeclaringType.ContainsKey(typeof(ISubApiC)),
+            "ISubApiC has no shared cache operation, so no options instance should carry one for it.");
+        Assert.Equal(CachePolicyOperationKind.Add, byDeclaringType[typeof(ISubApiA)][0].Value.Kind);
+        Assert.Equal(CachePolicyOperationKind.Disable, byDeclaringType[typeof(ISubApiB)][0].Value.Kind);
+
+        // ISubApiC still opted into library defaults but has no explicit consumer operations.
+        var subCOptions = allOptions.Single(o =>
+            o.CachePolicyOperations.All(x => x.Key.DeclaringType != typeof(ISubApiA))
+            && o.CachePolicyOperations.All(x => x.Key.DeclaringType != typeof(ISubApiB)));
+        Assert.Empty(subCOptions.CachePolicyOperations);
+        Assert.True(subCOptions.UseLibraryCacheDefaults);
+
+        void Shared(TestApiOptionsBuilder builder)
+        {
+            _ = builder
+                .WithBaseUrl("https://api.example.com")
+                .WithCachePartition("tenant:1")
+                .WithSharedCaching(sharedCache);
+        }
+    }
+
+    /// <summary>
+    /// Negative test: an operation targeting an interface that is NOT a registered sub-API must still surface
+    /// as a clear error via <see cref="SharedCacheConfiguration.ValidateAllOperationsMatched"/>, so real typos
+    /// are not silently swallowed.
+    /// </summary>
+    [Fact]
+    public void ValidateAllOperationsMatched_UnregisteredSubApi_SurfacesClearError()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddSingleton<IMxCache>(new FakeMxCache());
+
+        var sharedCache = new SharedCacheConfiguration(cache => cache
+            .InMemory<ISubApiA, Task<string>>(api => api.GetA(1, default), TimeSpan.FromSeconds(60))
+            .InMemory<IUnregisteredSubApi, Task<string>>(api => api.GetUnregistered(1, default), TimeSpan.FromSeconds(60)));
+
+        Action<TestApiOptionsBuilder> shared = Shared;
+
+        _ = services.AddTypedApiClient<ISubApiA, SubApiA, TestApiOptions, TestApiOptionsBuilder>(shared);
+
+        var ex = Assert.Throws<InvalidOperationException>(sharedCache.ValidateAllOperationsMatched);
+        Assert.Contains(nameof(IUnregisteredSubApi), ex.Message, StringComparison.Ordinal);
+
+        void Shared(TestApiOptionsBuilder builder)
+        {
+            _ = builder
+                .WithBaseUrl("https://api.example.com")
+                .WithCachePartition("tenant:1")
+                .WithSharedCaching(sharedCache);
+        }
+    }
+
+    /// <summary>
+    /// A minimal <see cref="IMxCache"/> so BuildServiceProvider succeeds without pulling any real cache infrastructure.
+    /// </summary>
+    private sealed class FakeMxCache : IMxCache
+    {
+        public Task<T> GetOrCreateAsync<T>(
+            CacheKey key,
+            CachePolicy policy,
+            Func<CancellationToken, ValueTask<T>> factory,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException("DI-composition tests do not exercise cache reads.");
+        }
+
+        public Task<CacheReadResult<T>> TryGetAsync<T>(CacheKey key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task SetAsync<T>(CacheKey key, T value, CachePolicy policy, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task RemoveAsync(CacheKey key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task RemoveByTagAsync(string tag, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/MX.Api.Client.Tests/SharedCacheConfigurationTests.cs
+++ b/src/MX.Api.Client.Tests/SharedCacheConfigurationTests.cs
@@ -1,0 +1,176 @@
+using MX.Api.Client.Configuration;
+using MX.Api.Client.Tests.TestClients;
+using MX.Caching.Abstractions;
+using Xunit;
+
+namespace MX.Api.Client.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SharedCacheConfiguration"/> and the
+/// <c>ApiClientOptionsBuilder&lt;,&gt;.WithSharedCaching</c> filtering / validation behavior.
+/// </summary>
+public class SharedCacheConfigurationTests
+{
+    [Fact]
+    public void Ctor_NullConfigure_ThrowsArgumentNullException()
+    {
+        _ = Assert.Throws<ArgumentNullException>(() => new SharedCacheConfiguration(null!));
+    }
+
+    [Fact]
+    public void WithSharedCaching_NullConfiguration_ThrowsArgumentNullException()
+    {
+        var builder = new TestApiOptionsBuilder();
+
+        _ = Assert.Throws<ArgumentNullException>(() => builder.WithSharedCaching(null!));
+    }
+
+    [Fact]
+    public void WithSharedCaching_AppliesOnlyOperationsMatchingConfiguredClientType()
+    {
+        var shared = new SharedCacheConfiguration(cache => cache
+            .InMemory<ISubApiA, Task<string>>(api => api.GetA(1, default), TimeSpan.FromMinutes(1))
+            .NotCached<ISubApiB, Task<string>>(api => api.GetB(2, default)));
+
+        var builderA = new TestApiOptionsBuilder();
+        builderA.SetConfiguredClientType(typeof(ISubApiA));
+        var optionsA = builderA
+            .WithBaseUrl("https://api.example.com")
+            .WithCachePartition("tenant:1")
+            .WithSharedCaching(shared)
+            .Build();
+
+        var opA = Assert.Single(optionsA.CachePolicyOperations);
+        Assert.Equal(typeof(ISubApiA), opA.Key.DeclaringType);
+        Assert.Equal(CachePolicyOperationKind.Add, opA.Value.Kind);
+        Assert.Equal(CacheTier.InProcess, opA.Value.Policy!.Tier);
+    }
+
+    [Fact]
+    public void WithSharedCaching_SkipsSiblingSubApiOperationsInsteadOfThrowing()
+    {
+        var shared = new SharedCacheConfiguration(cache => cache
+            .InMemory<ISubApiA, Task<string>>(api => api.GetA(1, default), TimeSpan.FromMinutes(1))
+            .NotCached<ISubApiB, Task<string>>(api => api.GetB(2, default)));
+
+        var builderB = new TestApiOptionsBuilder();
+        builderB.SetConfiguredClientType(typeof(ISubApiB));
+
+        // Would have thrown under the classic WithCaching(...) scope check.
+        var optionsB = builderB
+            .WithBaseUrl("https://api.example.com")
+            .WithCachePartition("tenant:1")
+            .WithSharedCaching(shared)
+            .Build();
+
+        var opB = Assert.Single(optionsB.CachePolicyOperations);
+        Assert.Equal(typeof(ISubApiB), opB.Key.DeclaringType);
+        Assert.Equal(CachePolicyOperationKind.Disable, opB.Value.Kind);
+    }
+
+    [Fact]
+    public void WithSharedCaching_UseLibraryDefaults_AppliesToEveryOptedInClient()
+    {
+        var shared = new SharedCacheConfiguration(cache => cache
+            .UseLibraryDefaults()
+            .InMemory<ISubApiA, Task<string>>(api => api.GetA(1, default), TimeSpan.FromMinutes(1)));
+
+        var builderA = new TestApiOptionsBuilder();
+        builderA.SetConfiguredClientType(typeof(ISubApiA));
+        var optionsA = builderA
+            .WithBaseUrl("https://api.example.com")
+            .WithCachePartition("tenant:1")
+            .WithSharedCaching(shared)
+            .Build();
+
+        var builderB = new TestApiOptionsBuilder();
+        builderB.SetConfiguredClientType(typeof(ISubApiB));
+        var optionsB = builderB
+            .WithBaseUrl("https://api.example.com")
+            .WithCachePartition("tenant:1")
+            .WithSharedCaching(shared)
+            .Build();
+
+        Assert.True(optionsA.UseLibraryCacheDefaults);
+        Assert.True(optionsB.UseLibraryCacheDefaults);
+    }
+
+    [Fact]
+    public void ValidateAllOperationsMatched_WithNoOperationsAndNoApplication_Succeeds()
+    {
+        var shared = new SharedCacheConfiguration(_ => { });
+
+        shared.ValidateAllOperationsMatched();
+    }
+
+    [Fact]
+    public void ValidateAllOperationsMatched_NeverApplied_ThrowsWhenOperationsWereCaptured()
+    {
+        var shared = new SharedCacheConfiguration(cache => cache
+            .InMemory<ISubApiA, Task<string>>(api => api.GetA(1, default), TimeSpan.FromMinutes(1)));
+
+        var ex = Assert.Throws<InvalidOperationException>(shared.ValidateAllOperationsMatched);
+        Assert.Contains("never applied", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateAllOperationsMatched_AllOperationsMatched_Succeeds()
+    {
+        var shared = new SharedCacheConfiguration(cache => cache
+            .InMemory<ISubApiA, Task<string>>(api => api.GetA(1, default), TimeSpan.FromMinutes(1))
+            .NotCached<ISubApiB, Task<string>>(api => api.GetB(2, default)));
+
+        var builderA = new TestApiOptionsBuilder();
+        builderA.SetConfiguredClientType(typeof(ISubApiA));
+        _ = builderA.WithBaseUrl("https://api.example.com").WithCachePartition("t").WithSharedCaching(shared);
+
+        var builderB = new TestApiOptionsBuilder();
+        builderB.SetConfiguredClientType(typeof(ISubApiB));
+        _ = builderB.WithBaseUrl("https://api.example.com").WithCachePartition("t").WithSharedCaching(shared);
+
+        shared.ValidateAllOperationsMatched();
+    }
+
+    [Fact]
+    public void ValidateAllOperationsMatched_UnregisteredInterface_ThrowsWithClearMessage()
+    {
+        var shared = new SharedCacheConfiguration(cache => cache
+            .InMemory<ISubApiA, Task<string>>(api => api.GetA(1, default), TimeSpan.FromMinutes(1))
+            .InMemory<IUnregisteredSubApi, Task<string>>(api => api.GetUnregistered(1, default), TimeSpan.FromMinutes(1)));
+
+        var builderA = new TestApiOptionsBuilder();
+        builderA.SetConfiguredClientType(typeof(ISubApiA));
+        _ = builderA.WithBaseUrl("https://api.example.com").WithCachePartition("t").WithSharedCaching(shared);
+
+        var ex = Assert.Throws<InvalidOperationException>(shared.ValidateAllOperationsMatched);
+        Assert.Contains(nameof(IUnregisteredSubApi), ex.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(IUnregisteredSubApi.GetUnregistered), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SharedCacheConfiguration_Ctor_SynchronousMethod_ThrowsAtCaptureTime()
+    {
+        // Genuine typos in the delegate itself still surface eagerly.
+        _ = Assert.Throws<ArgumentException>(() => new SharedCacheConfiguration(cache =>
+            cache.InMemory<ISynchronousShim, string>(api => api.Get(), TimeSpan.FromMinutes(1))));
+    }
+
+    /// <summary>
+    /// Regression: existing single-client <c>WithCaching(...)</c> continues to throw on a real scope mismatch,
+    /// preserving typo safety.
+    /// </summary>
+    [Fact]
+    public void WithCaching_SingleClient_ScopeMismatch_StillThrows()
+    {
+        var builderA = new TestApiOptionsBuilder();
+        builderA.SetConfiguredClientType(typeof(ISubApiA));
+
+        _ = Assert.Throws<ArgumentException>(() => builderA.WithCaching(cache => cache
+            .InMemory<ISubApiB, Task<string>>(api => api.GetB(1, default), TimeSpan.FromMinutes(1))));
+    }
+
+    private interface ISynchronousShim
+    {
+        string Get();
+    }
+}

--- a/src/MX.Api.Client.Tests/TestClients/UnifiedSubApis.cs
+++ b/src/MX.Api.Client.Tests/TestClients/UnifiedSubApis.cs
@@ -1,0 +1,86 @@
+using Microsoft.Extensions.Logging;
+using MX.Api.Client.Auth;
+
+namespace MX.Api.Client.Tests.TestClients;
+
+/// <summary>
+/// First fake sub-API used to mirror the unified-client registration shape.
+/// </summary>
+public interface ISubApiA
+{
+    /// <summary>Sample cached-eligible method.</summary>
+    Task<string> GetA(int id, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Second fake sub-API used to mirror the unified-client registration shape.
+/// </summary>
+public interface ISubApiB
+{
+    /// <summary>Sample cached-eligible method.</summary>
+    Task<string> GetB(int id, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Third fake sub-API used to mirror the unified-client registration shape.
+/// </summary>
+public interface ISubApiC
+{
+    /// <summary>Sample cached-eligible method.</summary>
+    Task<string> GetC(int id, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Fake sub-API that is intentionally NOT registered as a typed client. Used to prove that unmatched
+/// operations in a <c>SharedCacheConfiguration</c> are surfaced as a clear error.
+/// </summary>
+public interface IUnregisteredSubApi
+{
+    /// <summary>Sample cached-eligible method on an interface that will not be registered.</summary>
+    Task<string> GetUnregistered(int id, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Implementation of <see cref="ISubApiA"/>.</summary>
+public class SubApiA(
+    ILogger<BaseApi<TestApiOptions>> logger,
+    IApiTokenProvider? apiTokenProvider,
+    IRestClientService restClientService,
+    TestApiOptions options)
+    : BaseApi<TestApiOptions>(logger, apiTokenProvider, restClientService, options), ISubApiA
+{
+    /// <inheritdoc />
+    public Task<string> GetA(int id, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult($"A:{id}");
+    }
+}
+
+/// <summary>Implementation of <see cref="ISubApiB"/>.</summary>
+public class SubApiB(
+    ILogger<BaseApi<TestApiOptions>> logger,
+    IApiTokenProvider? apiTokenProvider,
+    IRestClientService restClientService,
+    TestApiOptions options)
+    : BaseApi<TestApiOptions>(logger, apiTokenProvider, restClientService, options), ISubApiB
+{
+    /// <inheritdoc />
+    public Task<string> GetB(int id, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult($"B:{id}");
+    }
+}
+
+/// <summary>Implementation of <see cref="ISubApiC"/>.</summary>
+public class SubApiC(
+    ILogger<BaseApi<TestApiOptions>> logger,
+    IApiTokenProvider? apiTokenProvider,
+    IRestClientService restClientService,
+    TestApiOptions options)
+    : BaseApi<TestApiOptions>(logger, apiTokenProvider, restClientService, options), ISubApiC
+{
+    /// <inheritdoc />
+    public Task<string> GetC(int id, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult($"C:{id}");
+    }
+}

--- a/src/MX.Api.Client/Configuration/ApiClientOptionsBuilder.cs
+++ b/src/MX.Api.Client/Configuration/ApiClientOptionsBuilder.cs
@@ -72,6 +72,29 @@ public abstract class ApiClientOptionsBuilder<TOptions, TBuilder>
         return (TBuilder)this;
     }
 
+    /// <summary>
+    /// Applies a <see cref="SharedCacheConfiguration"/> captured once and reused across multiple typed API client
+    /// registrations. Only operations whose declaring interface is assignable from the current typed client are
+    /// applied; expressions targeting sibling sub-APIs are skipped rather than throwing.
+    /// </summary>
+    /// <param name="sharedConfiguration">A cache configuration captured once for a "unified" set of typed API clients.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sharedConfiguration"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Use this method when a single consumer delegate registers cache policies against several typed sub-API interfaces
+    /// (for example, a repository client that composes many sub-APIs sharing one options / builder type). Call
+    /// <see cref="SharedCacheConfiguration.ValidateAllOperationsMatched"/> after all typed clients are registered to
+    /// surface typos where an operation targets an interface that was never registered. For genuine single-client
+    /// configuration, prefer <see cref="WithCaching(Action{CacheBuilder})"/>, which continues to throw on scope mismatch.
+    /// </remarks>
+    public TBuilder WithSharedCaching(SharedCacheConfiguration sharedConfiguration)
+    {
+        ArgumentNullException.ThrowIfNull(sharedConfiguration);
+
+        sharedConfiguration.ApplyTo(Options, _configuredClientType);
+        return (TBuilder)this;
+    }
+
     internal void SetConfiguredClientType(Type configuredClientType)
     {
         ArgumentNullException.ThrowIfNull(configuredClientType);

--- a/src/MX.Api.Client/Configuration/SharedCacheConfiguration.cs
+++ b/src/MX.Api.Client/Configuration/SharedCacheConfiguration.cs
@@ -1,0 +1,124 @@
+using System.Reflection;
+
+namespace MX.Api.Client.Configuration;
+
+/// <summary>
+/// Captures a single cache configuration delegate that spans multiple typed API clients so it can be
+/// applied per client without throwing when an expression targets a sibling sub-API interface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Designed for "unified" client scenarios where one consumer delegate registers cache policies against
+/// several typed sub-API interfaces (for example, a repository client that composes ~30 sub-APIs sharing
+/// one options / builder type). Use <see cref="ApiClientOptionsBuilder{TOptions, TBuilder}.WithSharedCaching(SharedCacheConfiguration)"/>
+/// from every per-client registration; each call applies only the operations whose declaring interface is
+/// assignable from the current typed client and records that they matched.
+/// </para>
+/// <para>
+/// After all typed clients are registered, call <see cref="ValidateAllOperationsMatched"/> to surface real
+/// typos: any operation whose declaring interface never matched a registered client will throw a descriptive
+/// <see cref="InvalidOperationException"/>. Single-client scope safety in the existing
+/// <see cref="ApiClientOptionsBuilder{TOptions, TBuilder}.WithCaching(Action{CacheBuilder})"/> is unchanged.
+/// </para>
+/// </remarks>
+public sealed class SharedCacheConfiguration
+{
+    private readonly List<CapturedOperation> _operations = [];
+    private readonly bool _useLibraryDefaults;
+    private readonly HashSet<MethodInfo> _matchedOperations = [];
+    private bool _appliedToAnyClient;
+
+    /// <summary>
+    /// Captures the cache configuration expressed by <paramref name="configure"/> without binding it to a
+    /// specific typed API client.
+    /// </summary>
+    /// <param name="configure">A cache configuration callback whose expressions may target multiple typed API interfaces.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
+    public SharedCacheConfiguration(Action<CacheBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var sink = new RecordingApiClientOptions();
+        configure(new CacheBuilder(sink, configuredClientType: null));
+
+        _useLibraryDefaults = sink.UseLibraryCacheDefaults;
+        foreach (var entry in sink.CachePolicyOperations)
+        {
+            _operations.Add(new CapturedOperation(entry.Key, entry.Value));
+        }
+    }
+
+    internal void ApplyTo(ApiClientOptionsBase options, Type? configuredClientType)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _appliedToAnyClient = true;
+
+        if (_useLibraryDefaults)
+        {
+            options.SetUseLibraryCacheDefaults(enabled: true);
+        }
+
+        foreach (var captured in _operations)
+        {
+            var declaringType = captured.Method.DeclaringType;
+            if (declaringType is null)
+            {
+                continue;
+            }
+
+            if (configuredClientType is null || declaringType.IsAssignableFrom(configuredClientType))
+            {
+                options.SetCachePolicyOperation(captured.Method, captured.Operation);
+                _ = _matchedOperations.Add(captured.Method);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that every captured cache operation matched at least one typed API client registered via
+    /// <see cref="ApiClientOptionsBuilder{TOptions, TBuilder}.WithSharedCaching(SharedCacheConfiguration)"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the shared configuration was never applied to a typed client, or when one or more operations target
+    /// an interface that was not registered as a typed client.
+    /// </exception>
+    public void ValidateAllOperationsMatched()
+    {
+        if (!_appliedToAnyClient)
+        {
+            if (_operations.Count == 0 && !_useLibraryDefaults)
+            {
+                return;
+            }
+
+            throw new InvalidOperationException(
+                "SharedCacheConfiguration was created but never applied via WithSharedCaching(...). " +
+                "Ensure every typed API client that should participate in shared caching calls WithSharedCaching(sharedCacheConfiguration).");
+        }
+
+        var unmatched = _operations
+            .Where(op => !_matchedOperations.Contains(op.Method))
+            .ToList();
+
+        if (unmatched.Count == 0)
+        {
+            return;
+        }
+
+        var summary = string.Join(
+            Environment.NewLine,
+            unmatched.Select(op => $"  - {op.Method.DeclaringType?.FullName}.{op.Method.Name}"));
+
+        throw new InvalidOperationException(
+            "The following shared cache operations did not match any typed API client registered via WithSharedCaching. " +
+            "Verify that each declaring interface is registered as a typed API client and that the shared configuration " +
+            "is passed to every registration:" + Environment.NewLine + summary);
+    }
+
+    private readonly record struct CapturedOperation(MethodInfo Method, CachePolicyOperation Operation);
+
+    private sealed class RecordingApiClientOptions : ApiClientOptionsBase
+    {
+    }
+}

--- a/src/MX.Api.Client/Configuration/SharedCacheConfiguration.cs
+++ b/src/MX.Api.Client/Configuration/SharedCacheConfiguration.cs
@@ -16,9 +16,18 @@ namespace MX.Api.Client.Configuration;
 /// </para>
 /// <para>
 /// After all typed clients are registered, call <see cref="ValidateAllOperationsMatched"/> to surface real
-/// typos: any operation whose declaring interface never matched a registered client will throw a descriptive
-/// <see cref="InvalidOperationException"/>. Single-client scope safety in the existing
-/// <see cref="ApiClientOptionsBuilder{TOptions, TBuilder}.WithCaching(Action{CacheBuilder})"/> is unchanged.
+/// typos: any operation whose declaring interface is not assignable from any registered client's typed
+/// interface will throw a descriptive <see cref="InvalidOperationException"/>. Single-client scope safety
+/// in the existing <see cref="ApiClientOptionsBuilder{TOptions, TBuilder}.WithCaching(Action{CacheBuilder})"/>
+/// is unchanged.
+/// </para>
+/// <para>
+/// Instances are stateful: <see cref="ApplyTo"/> records which captured operations have matched a typed
+/// client, so a single instance is intended for one registration pass against one
+/// <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection"/>. Do not share an instance across
+/// independent DI compositions — reusing an already-applied configuration in a second composition would leave
+/// the earlier match records in place and could mask real typos. Instances are not thread-safe; the expected
+/// usage is synchronous DI registration on a single thread.
 /// </para>
 /// </remarks>
 public sealed class SharedCacheConfiguration
@@ -81,7 +90,8 @@ public sealed class SharedCacheConfiguration
     /// </summary>
     /// <exception cref="InvalidOperationException">
     /// Thrown when the shared configuration was never applied to a typed client, or when one or more operations target
-    /// an interface that was not registered as a typed client.
+    /// a declaring interface that is not assignable from any registered typed client's interface (for example, no
+    /// registered sub-API implements or inherits the operation's declaring interface).
     /// </exception>
     public void ValidateAllOperationsMatched()
     {
@@ -108,12 +118,23 @@ public sealed class SharedCacheConfiguration
 
         var summary = string.Join(
             Environment.NewLine,
-            unmatched.Select(op => $"  - {op.Method.DeclaringType?.FullName}.{op.Method.Name}"));
+            unmatched.Select(op => "  - " + FormatMethodSignature(op.Method)));
 
         throw new InvalidOperationException(
             "The following shared cache operations did not match any typed API client registered via WithSharedCaching. " +
-            "Verify that each declaring interface is registered as a typed API client and that the shared configuration " +
-            "is passed to every registration:" + Environment.NewLine + summary);
+            "Verify that each declaring interface is assignable from a registered typed API client's interface " +
+            "(either the same interface or one it inherits) and that the shared configuration is passed to every registration:"
+            + Environment.NewLine + summary);
+    }
+
+    private static string FormatMethodSignature(MethodInfo method)
+    {
+        var declaringName = method.DeclaringType?.FullName ?? "<unknown>";
+        var parameters = string.Join(
+            ", ",
+            method.GetParameters().Select(p => p.ParameterType.FullName ?? p.ParameterType.Name));
+        var returnName = method.ReturnType.FullName ?? method.ReturnType.Name;
+        return $"{returnName} {declaringName}.{method.Name}({parameters})";
     }
 
     private readonly record struct CapturedOperation(MethodInfo Method, CachePolicyOperation Operation);


### PR DESCRIPTION
## Summary

Add a first-class, reflection-free `SharedCacheConfiguration` capability so a single cache-configuration delegate can be applied across many typed sub-API registrations without throwing for sibling sub-APIs. Locks the fix with a DI-composition regression test that would have caught the production incident.

Closes the production outage where a downstream unified client (XtremeIdiots Portal Repository client) crashed Functions hosts at startup with `ArgumentException: The expression must invoke a method declared by ...IAdminActionsApi ...` when the shared `configureOptions` delegate contained cache expressions targeting multiple sub-APIs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Root cause (recap)

`ApiClientOptionsBuilder<>.WithCaching(Action<CacheBuilder>)` constructs a `CacheBuilder` scoped to the current typed client type. When the same delegate is replayed across N typed clients (one call per sub-API), an expression declared on `IGameServersApi` throws the moment the delegate runs while the builder is scoped to a different sub-API (e.g. `IAdminActionsApi`). The throw happens inside DI registration, before the host is built.

Fix approach (Option A: capture-once, apply-filtered): keep the existing single-client `WithCaching(...)` scope safety unchanged, and add a new sibling `WithSharedCaching(SharedCacheConfiguration)` that captures the shared cache intent once and applies only the operations whose declaring interface is assignable from the current typed client. A final `ValidateAllOperationsMatched()` call surfaces genuine typos where an operation targets an interface that was never registered.

## Public API added

```csharp
// MX.Api.Client.Configuration
public sealed class SharedCacheConfiguration
{
    public SharedCacheConfiguration(Action<CacheBuilder> configure);
    public void ValidateAllOperationsMatched();
}

// MX.Api.Client.Configuration.ApiClientOptionsBuilder<TOptions, TBuilder>
public TBuilder WithSharedCaching(SharedCacheConfiguration sharedConfiguration);
```

Nothing in the existing public surface changes. `WithCaching(...)` continues to throw on real single-client scope mismatch, preserving typo safety.

## Consumer impact

**Published contract change (MX.Api.Client NuGet):** additive only — two new public members. No breaking changes.

**Downstream migration** (XtremeIdiots Portal Repository unified client — currently using private-reflection stopgap):

Before (unsupported, uses private reflection):
```csharp
services.AddTypedApiClient<IGameServersApi, GameServersApi, TOptions, TBuilder>(configureOptions);
// configureOptions contains .WithCaching(c => c.UseLibraryDefaults()
//     .InMemory<IGameServersApi, Task<...>>(x => x.GetGameServer(default, default), TimeSpan.FromSeconds(60)))
// -> throws when applied to sibling sub-APIs
```

After (supported, no reflection):
```csharp
using MX.Api.Client.Configuration;

var sharedCache = new SharedCacheConfiguration(c => c
    .UseLibraryDefaults()
    .InMemory<IGameServersApi, Task<ApiResult<GameServerDto>>>(
        x => x.GetGameServer(default, default), TimeSpan.FromSeconds(60))
    .NotCached<IAdminActionsApi, Task<ApiResult<AdminActionDto>>>(
        x => x.CreateAdminAction(default, default)));

void ConfigureOptions(UnifiedApiOptionsBuilder b) => b
    .WithBaseUrl(baseUrl)
    .WithApiKeyAuthentication(apiKey)
    .WithCachePartition(partition)
    .WithSharedCaching(sharedCache);

services.AddTypedApiClient<IGameServersApi, GameServersApi, UnifiedApiOptions, UnifiedApiOptionsBuilder>(ConfigureOptions);
services.AddTypedApiClient<IAdminActionsApi, AdminActionsApi, UnifiedApiOptions, UnifiedApiOptionsBuilder>(ConfigureOptions);
// ... repeat for each sub-API

sharedCache.ValidateAllOperationsMatched(); // surfaces any operation whose interface was never registered
```

The unified client's private reflection into `_configuredClientType` and `ApiClientOptionsBase.SetCachePolicyOperation` can then be deleted.

## Validation evidence

### Build

```
> dotnet build src/MX.Api.Abstractions.sln -nologo
Build succeeded.
    0 Error(s)
```

### Tests (default CI filter — the DI-composition regression test is included here)

```
> dotnet test src/MX.Api.Abstractions.sln --filter "FullyQualifiedName!~IntegrationTests" --nologo
Passed!  - Failed:     0, Passed:    68, Skipped:     0, Total:    68 - MX.Api.Abstractions.Tests.dll (net9.0)
Passed!  - Failed:     0, Passed:    68, Skipped:     0, Total:    68 - MX.Api.Abstractions.Tests.dll (net10.0)
Passed!  - Failed:     0, Passed:    30, Skipped:     0, Total:    30 - MX.Api.Web.Extensions.Tests.dll (net9.0)
Passed!  - Failed:     0, Passed:    30, Skipped:     0, Total:    30 - MX.Api.Web.Extensions.Tests.dll (net10.0)
Passed!  - Failed:     0, Passed:   142, Skipped:     0, Total:   142 - MX.Api.Client.Tests.dll (net9.0)
Passed!  - Failed:     0, Passed:   142, Skipped:     0, Total:   142 - MX.Api.Client.Tests.dll (net10.0)
```

New tests (all under default filter):

- `MX.Api.Client.Tests.Extensions.UnifiedApiClientRegistrationTests`
  - `SharedWithCachingDelegate_AcrossMultipleTypedClients_StillThrows_ProvingRepro` — proves the incident under the old API.
  - `SharedWithCachingDelegate_ViaSharedCacheConfiguration_ComposesAllTypedClientsCleanly` — DI composition succeeds via the new API.
  - `SharedCacheConfiguration_OperationsLandOnMatchingClientOnly_NoCrossClientBleed` — per-client landing correctness.
  - `ValidateAllOperationsMatched_UnregisteredSubApi_SurfacesClearError` — real typo still surfaces.
- `MX.Api.Client.Tests.SharedCacheConfigurationTests` — 11 focused unit tests for capture, filter/apply, opt-in defaults, and validation semantics (including the regression test that `WithCaching` single-client scope mismatch still throws).

### Format check

```
> dotnet format src/MX.Api.Abstractions.sln --verify-no-changes
(no output — clean)
```

### Code review

Ran the `code-review` sub-agent on the change set. Findings:
- Filtering (`IsAssignableFrom`) — correct; handles inheritance and skips siblings.
- `ValidateAllOperationsMatched` — no false-positive on `UseLibraryDefaults()`-only usage.
- Thread-safety of `ApplyTo` — safe: `AddTypedApiClient` invokes `configureOptions` synchronously during DI composition on a single thread (see `ApiClientExtensions.cs` line 146). Flagged as a note if the delegate ever migrates to a lazy `IOptionsFactory` path in future.
- Existing `WithCaching` scope safety — preserved.
- Test coverage — all four required scenarios present.

No High or Medium findings requiring resolution.

## Risk and rollout

- **Blast radius:** additive to `MX.Api.Client` — two new public members. No existing behavior changes. Downstream consumers not using `SharedCacheConfiguration` see zero effect.
- **Auto-deploy?** No (NuGet library; nbgv/height-derived versioning). A maintainer will tag the release after merge (expected 2.3.77 or 2.4.0).
- **Manual steps post-merge:** (1) publish NuGet, (2) downstream (XtremeIdiots Portal Repository client) migrates from private reflection to `SharedCacheConfiguration` per the "Consumer impact" snippet above.
- **Rollback plan:** revert this PR and re-publish the prior NuGet version. Downstream can temporarily reinstate its private-reflection stopgap until the next release.

## Agent attestation

- [x] Read the required-reading list (`.github/copilot-instructions.md`, personal working preferences, org catalog, stack-specific instructions).
- [x] Ran `dotnet build src/MX.Api.Abstractions.sln` — succeeded, 0 warnings, 0 errors.
- [x] Ran `dotnet test src/MX.Api.Abstractions.sln --filter "FullyQualifiedName!~IntegrationTests"` — all 480 tests passed across net9.0 + net10.0 TFMs.
- [x] Ran `dotnet format src/MX.Api.Abstractions.sln --verify-no-changes` — clean.
- [x] Ran the `code-review` sub-agent — no High/Medium findings requiring resolution.
- [x] No secrets, tokens, connection strings, or GUIDs introduced.
- [x] No edits to `.github/workflows/`, `version.json`, `Directory.*.props`, or cross-repo contracts.
- [x] New public API surface documented above (Consumer impact section) so downstream migration is unambiguous.
